### PR TITLE
Supporting multiple cursor selections.

### DIFF
--- a/lib/uuidgen.coffee
+++ b/lib/uuidgen.coffee
@@ -9,4 +9,6 @@ module.exports =
       uuid ?= require('node-uuid')
       editor = atom.workspace.getActiveTextEditor()
       if editor
-          editor.insertText(uuid.v4())
+          sels = editor.getSelectionsOrderedByBufferPosition()
+          for sel in sels
+              sel.insertText(uuid.v4())


### PR DESCRIPTION
ATOM supports multiple cursors and if I spawn cursors, uuidgen should generate unique UUID for each cursor.
